### PR TITLE
Crunch down output PNG by a bit

### DIFF
--- a/qrcode.go
+++ b/qrcode.go
@@ -236,7 +236,10 @@ func (q *QRCode) Image(size int) image.Image {
 	offset := (size - realSize*pixelsPerModule) / 2
 
 	rect := image.Rectangle{Min: image.Point{0, 0}, Max: image.Point{size, size}}
-	img := image.NewRGBA(rect)
+
+	// Saves a few bytes to have them in this order
+	p := color.Palette([]color.Color{q.BackgroundColor, q.ForegroundColor})
+	img := image.NewPaletted(rect, p)
 
 	for i := 0; i < size; i++ {
 		for j := 0; j < size; j++ {
@@ -269,8 +272,10 @@ func (q *QRCode) Image(size int) image.Image {
 func (q *QRCode) PNG(size int) ([]byte, error) {
 	img := q.Image(size)
 
+	encoder := png.Encoder{CompressionLevel: png.BestCompression}
+
 	var b bytes.Buffer
-	err := png.Encode(&b, img)
+	err := encoder.Encode(&b, img)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change has the library emit a pallated PNG instead of a full color range PNG, and will use better compression by default. This saves 30-40% on the PNG size, which makes them more suitable for embedding in things like emails.