### PR TITLE
create smaller QR codes with ToSmallString

### DIFF
--- a/qrcode.go
+++ b/qrcode.go
@@ -552,3 +552,42 @@ func (q *QRCode) ToString(inverseColor bool) string {
 	}
 	return buf.String()
 }
+
+// ToSmallString produces a multi-line string that forms a QR-code image, a
+// factor two smaller in x and y then ToString.
+func (q *QRCode) ToSmallString(inverseColor bool) string {
+	bits := q.Bitmap()
+	var buf bytes.Buffer
+	// if there is an odd number of rows, the last one needs special treatment
+	for y := 0; y < len(bits)-1; y += 2 {
+		for x := range bits[y] {
+			if bits[y][x] == bits[y+1][x] {
+				if bits[y][x] != inverseColor {
+					buf.WriteString(" ")
+				} else {
+					buf.WriteString("█")
+				}
+			} else {
+				if bits[y][x] != inverseColor {
+					buf.WriteString("▄")
+				} else {
+					buf.WriteString("▀")
+				}
+			}
+		}
+		buf.WriteString("\n")
+	}
+	// special treatment for the last row if odd
+	if len(bits)%2 == 1 {
+		y := len(bits) - 1
+		for x := range bits[y] {
+			if bits[y][x] != inverseColor {
+				buf.WriteString(" ")
+			} else {
+				buf.WriteString("▀")
+			}
+		}
+		buf.WriteString("\n")
+	}
+	return buf.String()
+}


### PR DESCRIPTION
I found the ToString generated QR codes are a bit big. I noticed the command line tool `qrencode` uses the characters ▄ and ▀ for two pixel rows per character row.

No strong preference from my side on the interface (function name or merge with ToString, …).