### PR TITLE
Improve img bitmap fill performance

### DIFF
--- a/qrcode.go
+++ b/qrcode.go
@@ -293,11 +293,11 @@ func (q *QRCode) Image(size int) image.Image {
 	// Saves a few bytes to have them in this order
 	p := color.Palette([]color.Color{q.BackgroundColor, q.ForegroundColor})
 	img := image.NewPaletted(rect, p)
+	bgClr := uint8(img.Palette.Index(q.BackgroundColor))
+	fgClr := uint8(img.Palette.Index(q.ForegroundColor))
 
-	for i := 0; i < size; i++ {
-		for j := 0; j < size; j++ {
-			img.Set(i, j, q.BackgroundColor)
-		}
+	for i := range img.Pix {
+		img.Pix[i] = bgClr
 	}
 
 	bitmap := q.symbol.bitmap()
@@ -308,7 +308,8 @@ func (q *QRCode) Image(size int) image.Image {
 				startY := y*pixelsPerModule + offset
 				for i := startX; i < startX+pixelsPerModule; i++ {
 					for j := startY; j < startY+pixelsPerModule; j++ {
-						img.Set(i, j, q.ForegroundColor)
+						pos := img.PixOffset(i, j)
+						img.Pix[pos] = fgClr
 					}
 				}
 			}

--- a/qrcode.go
+++ b/qrcode.go
@@ -293,12 +293,7 @@ func (q *QRCode) Image(size int) image.Image {
 	// Saves a few bytes to have them in this order
 	p := color.Palette([]color.Color{q.BackgroundColor, q.ForegroundColor})
 	img := image.NewPaletted(rect, p)
-	bgClr := uint8(img.Palette.Index(q.BackgroundColor))
 	fgClr := uint8(img.Palette.Index(q.ForegroundColor))
-
-	for i := range img.Pix {
-		img.Pix[i] = bgClr
-	}
 
 	bitmap := q.symbol.bitmap()
 	for y, row := range bitmap {


### PR DESCRIPTION
Thanks for your great work, this is the best qrcode lib I could find. But in production usage, we see an minor performance issue, and have a fix (hopefully) for it.

The following benchmark is about **5 times faster** after this patch (the impact increases with the image size).
```
func BenchmarkQrCodeOnly(b *testing.B) {
	for i := 0; i < b.N; i++ {
		q, _ := qrcode.New(fmt.Sprintf("abcdefg %d", i), qrcode.Low)
		q.Image(-7)
	}
}
```

The problem is just in `img.Set(i, j, Color)`, There is no need to calculate the color index in the palette for each pixel.