### PR TITLE
Occasional byte encoding efficiency over mixed encoding

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -180,6 +180,25 @@ func (d *dataEncoder) encode(data []byte) (*bitset.Bitset, error) {
 		return nil, err
 	}
 
+	// Check if a single byte encoded segment would be more efficient.
+	optimizedLength := 0
+	for _, s := range d.optimised {
+		length, err := d.encodedLength(s.dataMode, len(s.data))
+		if err != nil {
+			return nil, err
+		}
+		optimizedLength += length
+	}
+
+	singleByteSegmentLength, err := d.encodedLength(dataModeByte, len(d.data))
+	if err != nil {
+		return nil, err
+	}
+
+	if singleByteSegmentLength <= optimizedLength {
+		d.optimised = []segment{segment{dataMode: dataModeByte, data: d.data}}
+	}
+
 	// Encode data.
 	encoded := bitset.New()
 	for _, s := range d.optimised {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -180,17 +180,49 @@ func TestOptimiseEncoding(t *testing.T) {
 		{
 			dataEncoderType1To9,
 			[]testModeSegment{
+				{dataModeAlphanumeric, 100},
+				{dataModeByte, 1},
+				{dataModeNumeric, 1},
+			},
+			[]testModeSegment{
+				{dataModeAlphanumeric, 100},
+				{dataModeByte, 2},
+			},
+		},
+		// Sometimes encoding everything as bytes is more efficient.
+		{
+			dataEncoderType1To9,
+			[]testModeSegment{
 				{dataModeAlphanumeric, 1},
 				{dataModeByte, 1},
 				{dataModeNumeric, 1},
 			},
 			[]testModeSegment{
+				{dataModeByte, 3},
+			},
+		},
+		// https://www.google.com/123456789012345678901234567890
+		// BBBBBAAABBBABBBBBBABBBANNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+		{
+			dataEncoderType1To9,
+			[]testModeSegment{
+				{dataModeByte, 5},
+				{dataModeAlphanumeric, 3},
+				{dataModeByte, 3},
 				{dataModeAlphanumeric, 1},
-				{dataModeByte, 2},
+				{dataModeByte, 6},
+				{dataModeAlphanumeric, 1},
+				{dataModeAlphanumeric, 4},
+				{dataModeNumeric, 30},
+			},
+			[]testModeSegment{
+				{dataModeByte, 23},
+				{dataModeNumeric, 30},
 			},
 		},
 		// https://www.google.com/123
 		// BBBBBAAABBBABBBBBBABBBANNN
+		// Small segments are inefficient because of additional metadata.
 		{
 			dataEncoderType1To9,
 			[]testModeSegment{
@@ -204,8 +236,7 @@ func TestOptimiseEncoding(t *testing.T) {
 				{dataModeNumeric, 3},
 			},
 			[]testModeSegment{
-				{dataModeByte, 23},
-				{dataModeNumeric, 3},
+				{dataModeByte, 26},
 			},
 		},
 		// HTTPS://WWW.GOOGLE.COM/123


### PR DESCRIPTION
Sometimes mixed encoding is less efficient than encoding everything as a single byte segment due to additional segments headers.

This pull request adds a switch to a single byte encoded segment in cases where it is suitable. Tests are adjusted as long as they contained samples that are smaller when encoded as single segments.