### PR TITLE
Export NewWithForcedVersion

### DIFF
--- a/qrcode.go
+++ b/qrcode.go
@@ -51,6 +51,7 @@ package qrcode
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -199,7 +200,13 @@ func New(content string, level RecoveryLevel) (*QRCode, error) {
 	return q, nil
 }
 
-func newWithForcedVersion(content string, version int, level RecoveryLevel) (*QRCode, error) {
+// NewWithForcedVersion constructs a QRCode of a specific version.
+//
+//	var q *qrcode.QRCode
+//	q, err := qrcode.NewWithForcedVersion("my content", 25, qrcode.Medium)
+//
+// An error occurs in case of invalid version.
+func NewWithForcedVersion(content string, version int, level RecoveryLevel) (*QRCode, error) {
 	var encoder *dataEncoder
 
 	switch {
@@ -210,7 +217,7 @@ func newWithForcedVersion(content string, version int, level RecoveryLevel) (*QR
 	case version >= 27 && version <= 40:
 		encoder = newDataEncoder(dataEncoderType27To40)
 	default:
-		log.Fatalf("Invalid version %d (expected 1-40 inclusive)", version)
+		return nil, fmt.Errorf("Invalid version %d (expected 1-40 inclusive)", version)
 	}
 
 	var encoded *bitset.Bitset

--- a/qrcode_decode_test.go
+++ b/qrcode_decode_test.go
@@ -93,7 +93,7 @@ func TestDecodeAllVersionLevels(t *testing.T) {
 				version,
 				level)
 
-			q, err := newWithForcedVersion(
+			q, err := NewWithForcedVersion(
 				fmt.Sprintf("v-%d l-%d", version, level), version, level)
 			if err != nil {
 				t.Fatal(err.Error())


### PR DESCRIPTION
Sometimes it is very convenient to be able to specify a version for QR code generation.

For example in case when QR code would be embedded into a form with specific layout. In this case if data to be encoded has variable length, then smaller data blocks would be encoded in smaller QR codes and potentially ruin form layout.

This pull request exports `NewWithForcedVersion` function. It also substitutes `log.Fatalf` invocation with error return to make function behavior more predictable.

