### PR TITLE
Allow for encoding in color

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -22,6 +22,14 @@ func TestExampleEncode(t *testing.T) {
 	}
 }
 
+func TestExampleEncodeColor(t *testing.T) {
+	if png, err := EncodeColor("https://example.org", Medium, 256, color.RGBA{R: 255, A: 255}, color.RGBA{G: 255, A: 255}); err != nil {
+		t.Errorf("Error: %s", err.Error())
+	} else {
+		fmt.Printf("PNG is %d bytes long", len(png))
+	}
+}
+
 func TestExampleWriteFile(t *testing.T) {
 	filename := "example.png"
 	if err := WriteFile("https://example.org", Medium, 256, filename); err != nil {

--- a/qrcode.go
+++ b/qrcode.go
@@ -83,6 +83,30 @@ func Encode(content string, level RecoveryLevel, size int) ([]byte, error) {
 	return q.PNG(size)
 }
 
+// EncodeColor a QR Code and return a raw PNG image.
+// With EncodeColor you can also specify the colors you want to use.
+//
+// size is both the image width and height in pixels. If size is too small then
+// a larger image is silently returned. Negative values for size cause a
+// variable sized image to be returned: See the documentation for Image().
+//
+// To serve over HTTP, remember to send a Content-Type: image/png header.
+func EncodeColor(content string, level RecoveryLevel, size int, background,
+	foreground color.Color) ([]byte, error) {
+	var q *QRCode
+
+	q, err := New(content, level)
+
+	q.BackgroundColor = background
+	q.ForegroundColor = foreground
+
+	if err != nil {
+		return nil, err
+	}
+
+	return q.PNG(size)
+}
+
 // WriteFile encodes, then writes a QR Code to the given filename in PNG format.
 //
 // size is both the image width and height in pixels. If size is too small then

--- a/qrcode_decode_test.go
+++ b/qrcode_decode_test.go
@@ -122,7 +122,7 @@ func TestDecodeAllCharacters(t *testing.T) {
 
 	// zbarimg has trouble with null bytes, hence start from ASCII 1.
 	for i := 1; i < 256; i++ {
-		content += string(i)
+		content += string(rune(i))
 	}
 
 	q, err := New(content, Low)
@@ -154,7 +154,7 @@ func TestDecodeFuzz(t *testing.T) {
 		for j := 0; j < len; j++ {
 			// zbarimg seems to have trouble with special characters, test printable
 			// characters only for now.
-			content += string(32 + r.Intn(94))
+			content += string(rune(32 + r.Intn(94)))
 		}
 
 		for _, level := range []RecoveryLevel{Low, Medium, High, Highest} {


### PR DESCRIPTION
Created `EncodeColor` in order to create custom colored QR codes when writing to a file is not possible.

Also implemented the same fix as in #53 in order to run tests.